### PR TITLE
Feat/#2 backtest

### DIFF
--- a/app/api/v1/endpoints/backtest.py
+++ b/app/api/v1/endpoints/backtest.py
@@ -13,7 +13,11 @@ router = APIRouter()
     "",
     response_model=BaseResponse,
     summary="백테스트 실행",
-    description="stock_id, pattern_id, 날짜 범위를 기반으로 백테스트를 실행합니다.",
+    description=(
+        "stock_id, pattern_id, 날짜 범위를 기반으로 백테스트를 실행합니다.<br><br>"
+        "**지원 단위**: `MINUTE` / `HOUR` / `DAY`<br>"
+        "⚠️ 단위가 `MINUTE`일 경우 `15의 배수 값`만 허용됩니다."
+    ),
     tags=["Backtest"]
 )
 def run_backtest(

--- a/app/api_payload/code/error_status.py
+++ b/app/api_payload/code/error_status.py
@@ -12,10 +12,13 @@ class ErrorStatus(Enum):
     STOCK_OHLCV_NOT_FOUND = ("STOCK_OHLCV_NOT_FOUND", "종목 데이터를 찾을 수 없습니다.", status.HTTP_404_NOT_FOUND)
 
     # 백테스팅
-    BACKTEST_FAILED = ("BACKTEST_FAILED", "백테스트 실행 중 오류가 발생했습니다.", status.HTTP_500_INTERNAL_SERVER_ERROR)
+    NO_MATCHED_SECTION = ("NO_MATCHED_SECTION", "패턴과 유사한 구간이 없어 백테스트를 수행할 수 없습니다.", status.HTTP_400_BAD_REQUEST)
     INVALID_UNIT = ("INVALID_UNIT", "지원하지 않는 단위입니다.", status.HTTP_400_BAD_REQUEST)
     INVALID_UNIT_VALUE = ("INVALID_UNIT_VALUE", "단위 값이 유효하지 않습니다.", status.HTTP_400_BAD_REQUEST)
     INVALID_DATE_RANGE = ("INVALID_DATE_RANGE", "실행 기간이 유효하지 않습니다.", status.HTTP_400_BAD_REQUEST)
+    NO_RESAMPLED_DATA = ("NO_RESAMPLED_DATA", "리샘플링 결과가 존재하지 않습니다.", status.HTTP_400_BAD_REQUEST)
+    PATTERN_TOO_FLAT = ("PATTERN_TOO_FLAT", "패턴 값이 거의 일정하여 비교할 수 없습니다.", status.HTTP_400_BAD_REQUEST)
+    NOT_ENOUGH_DATA = ("NOT_ENOUGH_DATA", "시계열 데이터가 패턴보다 짧아 비교할 수 없습니다.", status.HTTP_400_BAD_REQUEST)
 
     # 패턴
     PATTERN_NOT_FOUND = ("PATTERN_NOT_FOUND", "해당 패턴을 찾을 수 없습니다.", status.HTTP_404_NOT_FOUND)

--- a/app/api_payload/code/error_status.py
+++ b/app/api_payload/code/error_status.py
@@ -9,9 +9,13 @@ class ErrorStatus(Enum):
 
     # 종목
     STOCK_NOT_FOUND = ("STOCK_NOT_FOUND", "해당 종목을 찾을 수 없습니다.", status.HTTP_404_NOT_FOUND)
+    STOCK_OHLCV_NOT_FOUND = ("STOCK_OHLCV_NOT_FOUND", "종목 데이터를 찾을 수 없습니다.", status.HTTP_404_NOT_FOUND)
 
     # 백테스팅
     BACKTEST_FAILED = ("BACKTEST_FAILED", "백테스트 실행 중 오류가 발생했습니다.", status.HTTP_500_INTERNAL_SERVER_ERROR)
+    INVALID_UNIT = ("INVALID_UNIT", "지원하지 않는 단위입니다.", status.HTTP_400_BAD_REQUEST)
+    INVALID_UNIT_VALUE = ("INVALID_UNIT_VALUE", "단위 값이 유효하지 않습니다.", status.HTTP_400_BAD_REQUEST)
+    INVALID_DATE_RANGE = ("INVALID_DATE_RANGE", "실행 기간이 유효하지 않습니다.", status.HTTP_400_BAD_REQUEST)
 
     # 패턴
     PATTERN_NOT_FOUND = ("PATTERN_NOT_FOUND", "해당 패턴을 찾을 수 없습니다.", status.HTTP_404_NOT_FOUND)

--- a/app/api_payload/code/success_status.py
+++ b/app/api_payload/code/success_status.py
@@ -6,6 +6,7 @@ class SuccessStatus(Enum):
     SUCCESS = ("SUCCESS", "요청 성공.", status.HTTP_200_OK)
     STOCK_FOUND = ("STOCK_FOUND", "종목 조회 성공", status.HTTP_200_OK)
     PREDICTION_COMPLETE = ("PREDICTION_COMPLETE", "예측 완료", status.HTTP_200_OK)
+    BACKTEST_EXECUTED = ("BACKTEST_EXECUTED", "백테스팅 실행 성공", status.HTTP_200_OK)
 
     def __init__(self, code, message, http_status):
         self.code = code

--- a/app/crud/stock_timeseries.py
+++ b/app/crud/stock_timeseries.py
@@ -1,0 +1,22 @@
+from sqlalchemy.orm import Session
+from datetime import datetime, date
+from app.models.stock_ohlcv import StockOhlcv
+
+def get_stock_timeseries(
+    db: Session,
+    stock_id: int,
+    start_date: date,
+    end_date: date
+) -> list[tuple[datetime, float]]:
+    """
+    주어진 구간의 timestamp와 종가 리스트를
+    오름차순으로 반환합니다.
+    """
+    return (
+        db.query(StockOhlcv.timestamp, StockOhlcv.close)
+          .filter(StockOhlcv.stock_id == stock_id)
+          .filter(StockOhlcv.timestamp >= start_date)
+          .filter(StockOhlcv.timestamp <= end_date)
+          .order_by(StockOhlcv.timestamp.asc())
+          .all()
+    )

--- a/app/models/stock_ohlcv.py
+++ b/app/models/stock_ohlcv.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Column, BigInteger, DateTime, Float, ForeignKey, UniqueConstraint
+from app.models.base_model import BaseTimeModel
+
+class StockOhlcv(BaseTimeModel):
+    __tablename__ = "stock_ohlcv"
+
+    __table_args__ = (
+        UniqueConstraint("stock_id", "timestamp", name="uq_stock_timestamp"),
+    )
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+
+    stock_id = Column(BigInteger, ForeignKey("stock.id"), nullable=False)
+
+    timestamp = Column(DateTime, nullable=False)
+
+    open      = Column(Float,    nullable=False)
+
+    high      = Column(Float,    nullable=False)
+
+    low       = Column(Float,    nullable=False)
+
+    close     = Column(Float,    nullable=False)
+
+    volume    = Column(BigInteger, nullable=False)

--- a/app/schemas/backtest.py
+++ b/app/schemas/backtest.py
@@ -8,8 +8,8 @@ class BacktestRequest(BaseModel):
     model_config = {
         "json_schema_extra": {
             "example": {
-                "startDate": "2023-01-01",
-                "endDate": "2024-04-26"
+                "startDate": "2025-06-13",
+                "endDate": "2025-06-26"
             }
         }
     }

--- a/app/services/backtest_service.py
+++ b/app/services/backtest_service.py
@@ -21,28 +21,37 @@ class BacktestService:
     """
     @staticmethod
     def execute_backtest(stock_id: int, pattern_id: int, request: BacktestRequest, db: Session) -> BacktestResponse:
+
+        # 날짜 유효성 검사
         if request.startDate > request.endDate:
             logger.warning(f"[Service] 기간 오류: startDate {request.startDate} > endDate {request.endDate}")
             raise APIException(ErrorStatus.INVALID_DATE_RANGE)
 
+        # 종목 유효성 검사
         stock_obj = get_stock_by_id(db, stock_id)
         if not stock_obj:
             logger.warning(f"[Service] 존재하지 않는 종목 ID: {stock_id}")
             raise APIException(ErrorStatus.STOCK_NOT_FOUND)
 
+        # 패턴 유효성 검사
         pattern_obj = get_pattern_by_id(db, pattern_id)
         if not pattern_obj:
             logger.warning(f"[Service] 존재하지 않는 패턴 ID: {pattern_id}")
+            raise APIException(ErrorStatus.PATTERN_NOT_FOUND)
 
+        # 패턴 단위 및 값 검사
         unit = pattern_obj.period_unit.name
         value = pattern_obj.period_value
         BacktestService._validate_unit(unit, value)
 
+        # 종목 데이터 조회 및 리샘플링
         raw_timestamps, raw_closes = BacktestService._fetch_timeseries(db, stock_id, request.startDate, request.endDate)
         timestamps, closes = BacktestService._resample_series(raw_timestamps, raw_closes, unit, value)
 
+        # dtw 로직
         idxes, distances = BacktestService._find_match_indices(pattern_obj.points, closes, pattern_obj.tolerance)
 
+        # 수익률 계산
         returns = BacktestService._calculate_returns(idxes, closes, timestamps, unit, value, len(pattern_obj.points))
 
         return BacktestService._aggregate_results(returns, request.startDate, len(idxes))
@@ -72,12 +81,23 @@ class BacktestService:
         """
         DB에서 데이터를 조회합니다.
 
+        Parameters:
+            db: DB 세션
+            stock_id: 조회할 종목 ID
+            start_date: 시작 날짜
+            end_date: 종료 날짜
+
         Returns:
             타임스탬프 리스트, 종가 리스트
+
+        Raises:
+            APIException: 해당 종목의 데이터가 없는 경우
         """
         rows = get_stock_timeseries(db, stock_id, start_date, end_date)
         if not rows:
             raise APIException(ErrorStatus.STOCK_OHLCV_NOT_FOUND)
+
+        # (timestamp, close) 형태로 분리 후 리스트 반환
         timestamps, closes = zip(*rows)
         return list(timestamps), list(closes)
 
@@ -89,19 +109,37 @@ class BacktestService:
         value: int
     ) -> Tuple[List[datetime], List[float]]:
         """
-        15분봉 데이터를 사용자 설정 단위로 리샘플링합니다.
-        - MINUTE: 그대로 반환
-        - HOUR / DAY: 주기 단위마다 마지막 종가 기준으로 집계
+        15분봉 데이터를 사용자 설정 단위에 따라 리샘플링합니다.
+
+        Parameters:
+            timestamps: 원본 타임스탬프 리스트 (15분 단위 기준)
+            closes: 종가 리스트
+            unit: 단위
+            value: 값
 
         Returns:
-            리샘플링된 시계열 데이터
+            리샘플링된 타임스탬프 리스트, 종가 리스트
+            - MINUTE: 원본 그대로 반환
+            - HOUR/DAY: 해당 단위 기준으로 마지막 종가만 추출 (resample().last())
         """
+        # 시계열 데이터 프레임 생성, timestamp를 인덱스로 설정
         df = pd.DataFrame({'timestamp': timestamps, 'close': closes})
         df.set_index('timestamp', inplace=True)
+
         if unit == 'MINUTE':
             return timestamps, closes
+
+        # pandas 리샘플링 규칙 생성
         rule = f"{value}{ 'h' if unit=='HOUR' else 'D' }"
+
+        # 각 구간의 마지막 종가만 추출
         agg = df['close'].resample(rule).last().dropna()
+
+        # 리샘플링 결과 없을 경우 예외 발생
+        if agg.empty:
+            raise APIException(ErrorStatus.NO_RESAMPLED_DATA)
+
+        # 리스트 변환 후 반환
         return list(agg.index), list(agg.values)
 
     @staticmethod
@@ -115,30 +153,52 @@ class BacktestService:
 
         Parameters:
             pattern: 사용자 패턴
-            closes: 비교 대상 시계열
-            tolerance: 허용 가능한 DTW 거리 한계
+            closes: 비교 대상 종가 데이터
+            tolerance: 허용 가능한 DTW 거리 상한값
 
         Returns:
             시작 인덱스 리스트, 해당 거리 리스트
+
+        Raises:
+            APIException:
+                - 시계열이 패턴보다 짧은 경우
+                - 패턴의 분산이 0에 가까워 정규화가 불가능할 경우
         """
         pattern_length = len(pattern)
+
+        # 비교 대상 데이터가 패턴보다 짧은 경우
+        if len(closes) < pattern_length:
+            raise APIException(ErrorStatus.NOT_ENOUGH_DATA)
+
+        # 패턴을 z-score 정규화 (평균 0, 표준편차 1)
         norm_pat = BacktestService._zscore_normalize(pattern)
+
+        # 패턴 값이 모두 동일한 경우
         if norm_pat is None:
-            return [], []
+            raise APIException(ErrorStatus.PATTERN_TOO_FLAT)
+
         idxes, distances = [], []
         last_end = -1
+
+        # 슬라이딩 윈도우 방식으로 유사 구간 탐색
         for i in range(len(closes) - pattern_length  + 1):
             if i <= last_end:
+                # 이전 매칭 구간과 겹치지 않도록 넘김
                 continue
+
             win = closes[i:i+pattern_length ]
             norm_win = BacktestService._zscore_normalize(win)
+
+            # 분산 0일 경우
             if norm_win is None:
                 continue
+
+            # DTW 로직 구현
             dist_value, _ = fastdtw(norm_pat, norm_win, dist=lambda a, b: abs(a - b))
             if dist_value <= tolerance:
                 idxes.append(i)
-                distances.append(distances)
-                last_end = i + pattern_length  - 1
+                distances.append(dist_value)
+                last_end = i + pattern_length  - 1 # 매칭 구간 이후 다시 탐색
         return idxes, distances
 
     @staticmethod
@@ -147,14 +207,16 @@ class BacktestService:
         z-score 정규화를 수행합니다.
 
         Returns:
-            정규화된 시계열
-            if 분산이 0에 가까우면 None
+            - 정규화된 시계열 데이터
+            if 분산이 거의 0이면 (모든 값이 거의 동일하면) None 반환
         """
-        mean = sum(sequence) / len(sequence)
-        var = sum((x - mean) ** 2 for x in sequence) / len(sequence)
+        mean = sum(sequence) / len(sequence) # 평균 계산
+        var = sum((x - mean) ** 2 for x in sequence) / len(sequence) # 분산 계산
+
+        # 분산 0일 경우
         if var < 1e-8:
             return None
-        std = var ** 0.5
+        std = var ** 0.5 # 표준 편차 계산
         return [(x - mean) / std for x in sequence]
 
     @staticmethod
@@ -180,21 +242,35 @@ class BacktestService:
             (진입 시점, 수익률) 리스트
         """
         returns = []
+
+        # 매칭 구간 반복
         for idx in idxes:
+            # 진입 시점 : 패턴의 마지막 지점
             entry_i = idx + pat_len - 1
+            # 진입 시점이 데이터 범위 벗어나는 경우 넘김
             if entry_i >= len(closes):
                 continue
+            # 진입 시간 설정 (매수 시간)
             entry_time = timestamps[entry_i]
+
+            # 단위에 따른 목표 계산 (매도 목표 시간)
             if unit == 'DAY':
                 tgt = entry_time + timedelta(days=value)
             elif unit == 'HOUR':
                 tgt = entry_time + timedelta(hours=value)
             else:
                 tgt = entry_time + timedelta(minutes=value)
+
+            # 적절한 청산(매도) 시점 찾기 (이진 탐색)
             pos = bisect_left(timestamps, tgt)
+
+            # 범위 초과 시 마지막 종가로 설정
             if pos >= len(closes): pos = len(closes) - 1
+            # 이전 시점이 더 가까우면 뒤로 이동
             elif pos > 0 and (timestamps[pos] - tgt) > (tgt - timestamps[pos-1]): pos -= 1
+            # 진입가, 청산가 활용하여 수익률 계산
             entry_p, exit_p = closes[entry_i], closes[pos]
+            # 수익률
             returns.append((entry_time, (exit_p-entry_p)/entry_p * 100))
         return returns
 

--- a/app/services/backtest_service.py
+++ b/app/services/backtest_service.py
@@ -1,8 +1,15 @@
 import logging
-from datetime import date
+from bisect import bisect_left
+from datetime import timedelta, datetime, date
+from typing import List, Tuple, Optional
+import pandas as pd
+from fastdtw import fastdtw
 from sqlalchemy.orm import Session
-from app.crud import stock, pattern
-from app.schemas.backtest import BacktestRequest, BacktestResponse
+
+from app.crud.stock import get_stock_by_id
+from app.crud.pattern import get_pattern_by_id
+from app.crud.stock_timeseries import get_stock_timeseries
+from app.schemas.backtest import BacktestResponse, BacktestRequest
 from app.exceptions.base import APIException
 from app.api_payload.code.status_code import ErrorStatus
 
@@ -12,61 +19,225 @@ class BacktestService:
     """
     백테스트 관련 비즈니스 로직을 처리합니다.
     """
+    @staticmethod
+    def execute_backtest(stock_id: int, pattern_id: int, request: BacktestRequest, db: Session) -> BacktestResponse:
+        if request.startDate > request.endDate:
+            logger.warning(f"[Service] 기간 오류: startDate {request.startDate} > endDate {request.endDate}")
+            raise APIException(ErrorStatus.INVALID_DATE_RANGE)
+
+        stock_obj = get_stock_by_id(db, stock_id)
+        if not stock_obj:
+            logger.warning(f"[Service] 존재하지 않는 종목 ID: {stock_id}")
+            raise APIException(ErrorStatus.STOCK_NOT_FOUND)
+
+        pattern_obj = get_pattern_by_id(db, pattern_id)
+        if not pattern_obj:
+            logger.warning(f"[Service] 존재하지 않는 패턴 ID: {pattern_id}")
+
+        unit = pattern_obj.period_unit.name
+        value = pattern_obj.period_value
+        BacktestService._validate_unit(unit, value)
+
+        raw_timestamps, raw_closes = BacktestService._fetch_timeseries(db, stock_id, request.startDate, request.endDate)
+        timestamps, closes = BacktestService._resample_series(raw_timestamps, raw_closes, unit, value)
+
+        idxes, distances = BacktestService._find_match_indices(pattern_obj.points, closes, pattern_obj.tolerance)
+
+        returns = BacktestService._calculate_returns(idxes, closes, timestamps, unit, value, len(pattern_obj.points))
+
+        return BacktestService._aggregate_results(returns, request.startDate, len(idxes))
 
     @staticmethod
-    def execute_backtest(
-        stock_id: int,
-        pattern_id: int,
-        request: BacktestRequest,
-        db: Session
-    ) -> BacktestResponse:
+    def _validate_unit(unit: str, value: int):
         """
-        주어진 조건으로 백테스트를 실행합니다.
-
-        Args:
-            stock_id (int): 종목 ID
-            pattern_id (int): 패턴 ID
-            request (BacktestRequest): 시작일, 종료일
-            db (Session): SQLAlchemy 세션
-
-        Returns:
-            BacktestResponse: 백테스트 결과 응답
+        사용자 설정 단위(unit)와 값(value)이 유효한지 검증합니다.
 
         Raises:
-            APIException: 유효하지 않은 종목/패턴 ID
+            APIException: 유효하지 않은 단위 또는 값일 경우
         """
-        logger.debug(f"[Service] 백테스팅 시작 - stock_id: {stock_id}, pattern_id: {pattern_id}, 기간: {request.startDate} ~ {request.endDate}")
+        if unit == "MINUTE" and value % 15 != 0:
+            raise APIException(ErrorStatus.INVALID_UNIT_VALUE)
+        if unit in {"HOUR", "DAY"} and value < 1:
+            raise APIException(ErrorStatus.INVALID_UNIT_VALUE)
+        if unit not in {"MINUTE", "HOUR", "DAY"}:
+            raise APIException(ErrorStatus.INVALID_UNIT)
 
-        # TODO: 추후 실제 로직/DB 연동 구현
-        try:
-            stock_obj = stock.get_stock_by_id(db, stock_id)
-            if not stock_obj:
-                logger.warning(f"[Service] 존재하지 않는 종목 ID: {stock_id}")
-                raise APIException(ErrorStatus.STOCK_NOT_FOUND)
+    @staticmethod
+    def _fetch_timeseries(
+        db: Session,
+        stock_id: int,
+        start_date: date,
+        end_date: date
+    ) -> Tuple[List[datetime], List[float]]:
+        """
+        DB에서 데이터를 조회합니다.
 
-            pattern_obj = pattern.get_pattern_by_id(db, pattern_id)
-            if not pattern_obj:
-                logger.warning(f"[Service] 존재하지 않는 패턴 ID: {pattern_id}")
-                raise APIException(ErrorStatus.PATTERN_NOT_FOUND)
+        Returns:
+            타임스탬프 리스트, 종가 리스트
+        """
+        rows = get_stock_timeseries(db, stock_id, start_date, end_date)
+        if not rows:
+            raise APIException(ErrorStatus.STOCK_OHLCV_NOT_FOUND)
+        timestamps, closes = zip(*rows)
+        return list(timestamps), list(closes)
 
-            # TODO: 추후 실제 DTW 계산 로직 삽입
-            response = BacktestResponse(
-                matchedCount=12,
-                winRate=58.3,
-                averageReturn=7.4,
-                maxReturn=19.8,
-                maxReturnDate=date(2024, 4, 15),
-                minReturn=-6.2,
-                minReturnDate=date(2024, 2, 5),
-                totalReturn=88.1,
-                lastMatchedDate=date(2024, 5, 30),
-                lastMatchedReturn=5.6
+    @staticmethod
+    def _resample_series(
+        timestamps: List[datetime],
+        closes: List[float],
+        unit: str,
+        value: int
+    ) -> Tuple[List[datetime], List[float]]:
+        """
+        15분봉 데이터를 사용자 설정 단위로 리샘플링합니다.
+        - MINUTE: 그대로 반환
+        - HOUR / DAY: 주기 단위마다 마지막 종가 기준으로 집계
+
+        Returns:
+            리샘플링된 시계열 데이터
+        """
+        df = pd.DataFrame({'timestamp': timestamps, 'close': closes})
+        df.set_index('timestamp', inplace=True)
+        if unit == 'MINUTE':
+            return timestamps, closes
+        rule = f"{value}{ 'h' if unit=='HOUR' else 'D' }"
+        agg = df['close'].resample(rule).last().dropna()
+        return list(agg.index), list(agg.values)
+
+    @staticmethod
+    def _find_match_indices(
+        pattern: List[float],
+        closes: List[float],
+        tolerance: float
+    ) -> Tuple[List[int], List[float]]:
+        """
+        DTW를 통해 패턴과 유사한 구간 탐색합니다.
+
+        Parameters:
+            pattern: 사용자 패턴
+            closes: 비교 대상 시계열
+            tolerance: 허용 가능한 DTW 거리 한계
+
+        Returns:
+            시작 인덱스 리스트, 해당 거리 리스트
+        """
+        pattern_length = len(pattern)
+        norm_pat = BacktestService._zscore_normalize(pattern)
+        if norm_pat is None:
+            return [], []
+        idxes, distances = [], []
+        last_end = -1
+        for i in range(len(closes) - pattern_length  + 1):
+            if i <= last_end:
+                continue
+            win = closes[i:i+pattern_length ]
+            norm_win = BacktestService._zscore_normalize(win)
+            if norm_win is None:
+                continue
+            dist_value, _ = fastdtw(norm_pat, norm_win, dist=lambda a, b: abs(a - b))
+            if dist_value <= tolerance:
+                idxes.append(i)
+                distances.append(distances)
+                last_end = i + pattern_length  - 1
+        return idxes, distances
+
+    @staticmethod
+    def _zscore_normalize(sequence: List[float]) -> Optional[List[float]]:
+        """
+        z-score 정규화를 수행합니다.
+
+        Returns:
+            정규화된 시계열
+            if 분산이 0에 가까우면 None
+        """
+        mean = sum(sequence) / len(sequence)
+        var = sum((x - mean) ** 2 for x in sequence) / len(sequence)
+        if var < 1e-8:
+            return None
+        std = var ** 0.5
+        return [(x - mean) / std for x in sequence]
+
+    @staticmethod
+    def _calculate_returns(
+        idxes: List[int],
+        closes: List[float],
+        timestamps: List[datetime],
+        unit: str,
+        value: int,
+        pat_len: int
+    ) -> List[Tuple[datetime, float]]:
+        """
+        각 매칭 구간의 수익률 계산합니다.
+
+        Parameters:
+            idxes: 매칭 시작 인덱스 리스트
+            closes: 종가
+            timestamps: 타임스탬프
+            unit, value: 단위, 값
+            pat_len: 패턴 길이
+
+        Returns:
+            (진입 시점, 수익률) 리스트
+        """
+        returns = []
+        for idx in idxes:
+            entry_i = idx + pat_len - 1
+            if entry_i >= len(closes):
+                continue
+            entry_time = timestamps[entry_i]
+            if unit == 'DAY':
+                tgt = entry_time + timedelta(days=value)
+            elif unit == 'HOUR':
+                tgt = entry_time + timedelta(hours=value)
+            else:
+                tgt = entry_time + timedelta(minutes=value)
+            pos = bisect_left(timestamps, tgt)
+            if pos >= len(closes): pos = len(closes) - 1
+            elif pos > 0 and (timestamps[pos] - tgt) > (tgt - timestamps[pos-1]): pos -= 1
+            entry_p, exit_p = closes[entry_i], closes[pos]
+            returns.append((entry_time, (exit_p-entry_p)/entry_p * 100))
+        return returns
+
+    @staticmethod
+    def _aggregate_results(
+        returns: List[Tuple[datetime, float]],
+        start_date: date,
+        match_count: int
+    ) -> BacktestResponse:
+        """
+        최종 응답을 반환합니다.
+
+        Parameters:
+            returns: (진입 시점, 수익률) 리스트
+            match_count: 매칭된 구간 수
+
+        Returns:
+            BacktestResponse
+        """
+        if not returns:
+            return BacktestResponse(
+                matchedCount=match_count,
+                winRate=0.0,
+                averageReturn=0.0,
+                maxReturn=0.0,
+                maxReturnDate=start_date,
+                minReturn=0.0,
+                minReturnDate=start_date,
+                totalReturn=0.0,
+                lastMatchedDate=start_date,
+                lastMatchedReturn=0.0
             )
-
-            logger.debug(f"[Service] 백테스팅 완료 - stock_id: {stock_id}, pattern_id: {pattern_id}")
-            return response
-
-        except Exception as e:
-            logger.error(f"[Service] 백테스팅 실패 - {e}")
-            raise APIException(ErrorStatus.BACKTEST_FAILED)
-
+        dates, vals = zip(*returns)
+        wins = [v for v in vals if v > 0]
+        return BacktestResponse(
+            matchedCount=match_count,
+            winRate=len(wins)/len(vals) * 100,
+            averageReturn=sum(vals)/len(vals),
+            maxReturn=max(vals),
+            maxReturnDate=dates[vals.index(max(vals))].date(),
+            minReturn=min(vals),
+            minReturnDate=dates[vals.index(min(vals))].date(),
+            totalReturn=sum(vals),
+            lastMatchedDate=dates[-1].date(),
+            lastMatchedReturn=vals[-1]
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,5 @@ starlette==0.46.2
 typing-inspection==0.4.1
 typing_extensions==4.14.0
 uvicorn==0.34.3
+fastdtw==0.3.4
+pandas==2.2.2


### PR DESCRIPTION
## 🚀 개요
백테스트 서비스 로직 구현 및 예외 처리 개선

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #2 

## ⏳ 작업 내용
- 사용자 설정 단위(MINUTE/HOUR/DAY)에 따른 리샘플링 처리
- FastDTW 기반 패턴 유사도 계산
- Z-score 정규화
- 수익률 계산
- 예외 처리 및 커스텀 에러 코드 추가


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/d6083862-6ea6-4c54-8c40-58a1bbd3e671)

## 📝 참고 사항
<!-- 이 PR에 대한 논의하고 싶은 사항이나 더 해야할 작업, 리뷰어에게 특별히 확인 요청하고 싶은 부분 등을 적어주세요. -->
- 15분봉 주식 db에 맞춰 백테스팅 정확도 개선을 위해 사용자 패턴의 단위는 MINUTE, HOUR, DAY로 한정했습니다.
- 만약 단위가 MINUTE일 경우 값이 15의 배수일 경우만 백테스팅이 가능하도록 했습니다.