### PR TITLE
[DEL] 라우터 삭제 #25

### DIFF
--- a/app/api/v1/routers/__init__.py
+++ b/app/api/v1/routers/__init__.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter
-from app.api.v1.routers import stock_router, backtest_router, pattern_detection_router, emotion_diary_router
+from app.api.v1.routers import stock_router, backtest_router, pattern_detection_router
 
 router = APIRouter()
 
 router.include_router(stock_router.router, prefix="/v1")
 router.include_router(backtest_router.router, prefix="/v1")
 router.include_router(pattern_detection_router.router, prefix="/v1")
-router.include_router(emotion_diary_router.router, prefix="/v1")
+# router.include_router(emotion_diary_router.router, prefix="/v1")
 
 # 아래에 추가 ex. router.include_router(user_router.router, prefix="/v1")


### PR DESCRIPTION
## 🚀 개요
라우터 삭제

## 📌 관련 이슈
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
- Closes #25

## ⏳ 작업 내용
- 미구현 라우터 삭제


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 새 소식 없음

- Chores
  - 감정 일기 관련 API 라우트를 비활성화했습니다. v1에서 해당 엔드포인트는 더 이상 제공되지 않습니다.
  - 주식, 백테스트, 패턴 탐지 관련 기존 API는 영향 없이 정상 동작합니다.
  - 감정 일기 엔드포인트 호출 시 미제공(예: 404) 응답이 반환될 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->