### PR TITLE
[FIX] 이미지 업로드 크기 제한 상향 (5MB -> 20MB) #16

### DIFF
--- a/app/api/v1/endpoints/stocks/image_search.py
+++ b/app/api/v1/endpoints/stocks/image_search.py
@@ -17,7 +17,7 @@ router = APIRouter()
     summary="이미지 기반 종목 검색",
     description="""
                 업로드된 이미지로부터 브랜드를 인식하여 종목 정보를 반환합니다.
-                최대 5MB 파일만 업로드 가능합니다.
+                최대 20MB 파일만 업로드 가능합니다.
     """,
     tags=["Stock"]
 )
@@ -26,9 +26,9 @@ async def search_stock_by_image(
         db: Session = Depends(get_db)
 ):
     contents = await image.read()
-    MAX_IMAGE_SIZE = 5 * 1024 * 1024  # 5MB
+    MAX_IMAGE_SIZE = 20 * 1024 * 1024  # 20MB
 
-    # 파일 크기 제한(5MB)
+    # 파일 크기 제한
     if len(contents) > MAX_IMAGE_SIZE:
         raise APIException(ErrorStatus.FILE_TOO_LARGE)
 


### PR DESCRIPTION
## 🚀 개요
이미지 업로드 크기 제한을 상향 했습니다.

## 📌 관련 이슈
- Closes #16 

## ⏳ 작업 내용
- 이미지 업로드 크기 제한을 상향 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 이미지 검색 엔드포인트에서 업로드 허용 용량을 5MB에서 20MB로 확대하여 더 큰 이미지를 업로드할 수 있습니다.
- 문서
  - 라우트 설명을 최신 업로드 용량(20MB)에 맞게 갱신했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->