### PR TITLE
Feat/#38 backtest resample 15m to 1h

### DIFF
--- a/app/services/backtest_service.py
+++ b/app/services/backtest_service.py
@@ -2,6 +2,8 @@ import logging
 from bisect import bisect_left
 from datetime import datetime, date, timedelta, time
 from typing import List, Tuple
+
+import pandas as pd
 from sqlalchemy.orm import Session
 from app.crud.stock import get_stock_by_id
 from app.crud.pattern import get_pattern_by_id
@@ -88,19 +90,47 @@ class BacktestService:
         start_datetime = datetime.combine(start_date, time.min)
         end_datetime = datetime.combine(end_date, time.max)
 
-        rows = get_stock_timeseries_by_unit(
-            db=db,
-            stock_id=stock_id,
-            start_datetime=start_datetime,
-            end_datetime=end_datetime,
-            unit=unit)
+        # 단위가 HOUR인 경우
+        if unit == "HOUR":
+            # 15분봉 데이터 조회
+            rows = get_stock_timeseries_by_unit(
+                db=db,
+                stock_id=stock_id,
+                start_datetime=start_datetime,
+                end_datetime=end_datetime,
+                unit="MINUTE"
+            )
 
-        if not rows:
-            raise APIException(ErrorStatus.STOCK_OHLCV_NOT_FOUND)
+            if not rows:
+                raise APIException(ErrorStatus.STOCK_OHLCV_NOT_FOUND)
 
-        # (timestamp, close) 형태로 분리 후 리스트 반환
-        timestamps, closes = zip(*rows)
-        return list(timestamps), list(closes)
+            # DataFrame 변환
+            df = pd.DataFrame(rows, columns=["timestamp", "close"])
+            df.set_index("timestamp", inplace=True)
+
+            # 1시간 단위로 리샘플링
+            df_resampled = df.resample("1h").last().dropna()
+
+            timestamps = df_resampled.index.to_list()
+            closes = df_resampled["close"].to_list()
+            return timestamps, closes
+
+        # 단위가 DAY인 경우
+        else:
+            rows = get_stock_timeseries_by_unit(
+                db=db,
+                stock_id=stock_id,
+                start_datetime=start_datetime,
+                end_datetime=end_datetime,
+                unit=unit
+            )
+
+            if not rows:
+                raise APIException(ErrorStatus.STOCK_OHLCV_NOT_FOUND)
+
+            # (timestamp, close) 형태로 분리 후 리스트 반환
+            timestamps, closes = zip(*rows)
+            return list(timestamps), list(closes)
 
     @staticmethod
     def _calculate_returns(

--- a/app/services/backtest_service.py
+++ b/app/services/backtest_service.py
@@ -109,7 +109,9 @@ class BacktestService:
             df.set_index("timestamp", inplace=True)
 
             # 1시간 단위로 리샘플링
-            df_resampled = df.resample("1h").last().dropna()
+            df_resampled = df.resample("1H").last().dropna()
+            if df_resampled.empty:
+                raise APIException(ErrorStatus.NO_RESAMPLED_DATA)
 
             timestamps = df_resampled.index.to_list()
             closes = df_resampled["close"].to_list()

--- a/app/services/backtest_service.py
+++ b/app/services/backtest_service.py
@@ -10,7 +10,7 @@ from app.crud.pattern import get_pattern_by_id
 from app.crud.stock_timeseries import get_stock_timeseries_by_unit
 from app.schemas.backtest import BacktestResponse, BacktestRequest, HighlightRange
 from app.exceptions.base import APIException
-from app.api_payload.code.status_code import ErrorStatus
+from app.api_payload.code.error_status import ErrorStatus
 from app.utils.timeseries_calculator import (
     validate_unit,
     find_match_indices,

--- a/app/utils/unit_table_mapper.py
+++ b/app/utils/unit_table_mapper.py
@@ -2,8 +2,10 @@ from typing import Dict, Type
 
 from app.models.stock_ohlcv_1h import StockOhlcv1h
 from app.models.stock_ohlcv_1d import StockOhlcv1d
+from app.models.stock_ohlcv import StockOhlcv
 
 UNIT_TO_TABLE: Dict[str, Type] = {
     "HOUR": StockOhlcv1h,
     "DAY": StockOhlcv1d,
+    "MINUTE": StockOhlcv,
 }


### PR DESCRIPTION
## 🚀 개요
백테스팅을 진행할 때 저장된 데이터 부족으로 15분봉 데이터를 1시간봉 데이터로 리샘플링합니다.

## 📌 관련 이슈
- Closes #38 

## ⏳ 작업 내용
- 백테스팅 서비스에 리샘플링 로직 추가
- 단위 매핑 추가

## 📸 스크린샷
<img width="458" height="435" alt="스크린샷 2025-09-02 190852" src="https://github.com/user-attachments/assets/0ffb6dc5-9d56-4a98-9b56-f43578cd83f5" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 분(MINUTE) 단위 시계열 데이터 지원을 추가했습니다.
  - 시간(HOUR) 단위 백테스트 시 분 단위 종가를 집계해 시간별 시계열을 생성합니다.
- 버그 수정
  - 데이터 미존재 시 명확한 오류 안내로 처리 일관성을 개선했습니다.
  - 빈 구간을 제외하고 마지막 종가로 집계해 시계열 연속성을 향상시키고, 재샘플링 결과가 비어있을 경우 오류를 반환합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->